### PR TITLE
fix: Call to encodeOrderParams with null params

### DIFF
--- a/src/sign/encodeOrderParams.test.ts
+++ b/src/sign/encodeOrderParams.test.ts
@@ -13,6 +13,11 @@ describe("encodeOrderParams", () => {
     expect(paramsTypes).toEqual([]);
     expect(encodedParams).toEqual("0x");
   });
+  it("null params", () => {
+    const { paramsTypes, encodedParams } = encodeOrderParams(null);
+    expect(paramsTypes).toEqual([]);
+    expect(encodedParams).toEqual("0x");
+  });
   it("empty params", () => {
     const { paramsTypes, encodedParams } = encodeOrderParams([]);
     expect(paramsTypes).toEqual([]);

--- a/src/sign/encodeOrderParams.ts
+++ b/src/sign/encodeOrderParams.ts
@@ -7,8 +7,9 @@ import { SolidityType } from "../types";
  * @param params array of params
  * @returns param types and encoded params
  */
-export const encodeOrderParams = (params: any[] = []): { paramsTypes: SolidityType[]; encodedParams: BytesLike } => {
-  const paramsTypes: SolidityType[] = params.map((param): SolidityType => {
+export const encodeOrderParams = (params?: any[] | null): { paramsTypes: SolidityType[]; encodedParams: BytesLike } => {
+  const nonNullParams = params || [];
+  const paramsTypes: SolidityType[] = nonNullParams.map((param): SolidityType => {
     if (utils.isAddress(param)) {
       return "address";
     }
@@ -25,5 +26,5 @@ export const encodeOrderParams = (params: any[] = []): { paramsTypes: SolidityTy
     }
   });
 
-  return { paramsTypes, encodedParams: utils.defaultAbiCoder.encode(paramsTypes, params) };
+  return { paramsTypes, encodedParams: utils.defaultAbiCoder.encode(paramsTypes, nonNullParams) };
 };


### PR DESCRIPTION
encodeOrderParams crashes if params = null