### PR TITLE
Slippage logic fix on guide.md

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -34,7 +34,7 @@ const makerOrder: MakerOrder = {
   nonce: nonce.toNumber(),
   startTime: now,
   endTime: now + 86400, // 1 day validity
-  minPercentageToAsk: Math.min(netPriceRatio, minNetPriceRatio),
+  minPercentageToAsk: Math.max(netPriceRatio, minNetPriceRatio),
   params: paramsValue,
 };
 const signatureHash = await signMakerOrder(signer, chainId, makerOrder);


### PR DESCRIPTION
If you are enforcing a max slippage of 15% (as mentioned on line 22), then `minPercentageToAsk` shouldn't go below 8500 ✌️