### PR TITLE
fix: Missing exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export * from "./abis";
 export * from "./constants";
 export * from "./sign";
 export * from "./types";
-export { multicall } from "./multicall";
+export * from "./multicall";


### PR DESCRIPTION
Allow `Call` interface to be exported from `multicall`