### PR TITLE
Convert to Generic<T> for better type signatures

### DIFF
--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -1,4 +1,4 @@
-import { providers } from "ethers";
+import { BytesLike, providers } from "ethers";
 import { Interface } from "@ethersproject/abi";
 import { Contract } from "@ethersproject/contracts";
 import multicall2Abi from "./abis/Multicall2.json";
@@ -17,7 +17,7 @@ export interface Call {
  * @param abi abi generated from the contract code
  * @param calls Array of Call objects to run through multicall
  */
-export const multicall = async (provider: providers.Provider, address: string, abi: any[], calls: Call[]) => {
+export const multicall = async <T = unknown>(provider: providers.Provider, address: string, abi: any[], calls: Call[]): Promise<T[]> => {
   // Setup contracts
   const multicallContract = new Contract(address, multicall2Abi, provider);
   const itf = new Interface(abi);
@@ -35,7 +35,7 @@ export const multicall = async (provider: providers.Provider, address: string, a
   // will include all values positionally and if the ABI
   // included names, values will additionally be available
   // by their name.
-  const results: any[] = returnData.map((data: any, i: number) => {
+  const results: T[] = returnData.map((data: BytesLike, i: number) => {
     const [result] = itf.decodeFunctionResult(calls[i].functionName, data);
 
     return result;

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -17,7 +17,12 @@ export interface Call {
  * @param abi abi generated from the contract code
  * @param calls Array of Call objects to run through multicall
  */
-export const multicall = async <T = unknown>(provider: providers.Provider, address: string, abi: any[], calls: Call[]): Promise<T[]> => {
+export const multicall = async <T extends any[]>(
+  provider: providers.Provider,
+  address: string,
+  abi: any[],
+  calls: Call[]
+): Promise<T> => {
   // Setup contracts
   const multicallContract = new Contract(address, multicall2Abi, provider);
   const itf = new Interface(abi);
@@ -35,7 +40,7 @@ export const multicall = async <T = unknown>(provider: providers.Provider, addre
   // will include all values positionally and if the ABI
   // included names, values will additionally be available
   // by their name.
-  const results: T[] = returnData.map((data: BytesLike, i: number) => {
+  const results: T = returnData.map((data: BytesLike, i: number) => {
     const [result] = itf.decodeFunctionResult(calls[i].functionName, data);
 
     return result;


### PR DESCRIPTION
There are many use-cases where we want to have better type signatures throughout the codebase, since compile time types can't be inferred from the ABI currently ( though that would be very cool and someone should create that ) we must manually assign types.

Rather than cast as unknown as type e.g

```ts
 // Inferred type is Promise<any[]> by default without manual type cast
const [isInvalid] = (await multicall(provider, address, abi, calls)) as unknown as boolean[];
```

It would be preferable to make this generic where the default is not `any` but `unknown`... Not that converting the default <T> from `any` to `unknown` could be considered a breaking change. We could leave it as `any` by default which would retain compatibility. I've left default as any for now, however strictness would suggets `unknown.

```ts
// Inferred type is Promise<boolean[]>
const [isInvalid] = await multicall<boolean>(provider, address, abi, calls);
```