### PR TITLE
fix: Add typed signature support for Frame Wallet

### DIFF
--- a/src/sign/etherSignTypedData.ts
+++ b/src/sign/etherSignTypedData.ts
@@ -14,7 +14,7 @@ enum Wallet {
  */
 interface ExtendedJsonRpcProvider extends ethers.providers.JsonRpcProvider {
   provider?: {
-    isFrame?: boolean;
+    isFrame?: boolean; // Frame injected wallet
   };
 }
 

--- a/src/sign/etherSignTypedData.ts
+++ b/src/sign/etherSignTypedData.ts
@@ -4,7 +4,18 @@ import { _TypedDataEncoder } from "@ethersproject/hash";
 
 enum Wallet {
   METAMASK,
+  FRAME,
   OTHER,
+}
+
+/**
+ * Some provider instances extend the JsonRpcProvider API.
+ * Optional values here can be used to identify the wallet connector
+ */
+interface ExtendedJsonRpcProvider extends ethers.providers.JsonRpcProvider {
+  provider?: {
+    isFrame?: boolean;
+  };
 }
 
 /**
@@ -12,19 +23,27 @@ enum Wallet {
  * Never use server side
  * @returns Wallet
  */
-const getCurrentWallet = async (provider: ethers.providers.JsonRpcProvider): Promise<Wallet> => {
+const getCurrentWallet = async (provider: ExtendedJsonRpcProvider): Promise<Wallet> => {
   const isMetaMask = provider.connection.url === "metamask";
-  return isMetaMask ? Wallet.METAMASK : Wallet.OTHER;
+  const isFrame = provider.provider?.isFrame;
+
+  if (isMetaMask) {
+    return Wallet.METAMASK;
+  }
+  if (isFrame) {
+    return Wallet.FRAME;
+  }
+  return Wallet.OTHER;
 };
 
 /**
  * Copy of ethers '_signTypedData' helper, modified to support EIP-712 typed signatures with different call names
  * https://github.com/ethers-io/ethers.js/blob/73a46efea32c3f9a4833ed77896a216e3d3752a0/packages/providers/src.ts/json-rpc-provider.ts#L263
- * TESTED WITH - MetaMask, WalletConnect: Trust, Rainbow, MetaMask Mobile, SafePal
- * NOT CURRENTLY SUPPORTED - Trezor, TokenPocket, Math Wallet
+ * TESTED WITH - MetaMask, Frame, Coinbase Wallet, WalletConnect: Trust, Rainbow, MetaMask Mobile, SafePal, TokenPocket, Math Wallet
+ * NOT CURRENTLY SUPPORTED - Trezor
  */
 export const etherSignTypedData = async (
-  provider: ethers.providers.JsonRpcProvider,
+  provider: ExtendedJsonRpcProvider,
   address: string,
   domain: TypedDataDomain,
   types: Record<string, Array<TypedDataField>>,
@@ -40,8 +59,8 @@ export const etherSignTypedData = async (
 
   const wallet = await getCurrentWallet(provider);
 
-  if (wallet === Wallet.METAMASK) {
-    return await provider.send("eth_signTypedData_v4", [address, JSON.stringify(rpcData)]); // MetaMask injected
+  if (wallet === Wallet.METAMASK || wallet === Wallet.FRAME) {
+    return await provider.send("eth_signTypedData_v4", [address, JSON.stringify(rpcData)]); // MetaMask, Frame
   }
 
   return await provider.send("eth_signTypedData", [address, JSON.stringify(rpcData)]); // CoinBase wallet. WalletConnect: Trust, MetaMask Mobile, Rainbow, SafePal


### PR DESCRIPTION
frame.sh uses `eth_signTypedData_v4`. 
This expands conditional logic so that frame uses the v4 func.