### PR TITLE
Remove link emoji and use text links

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -14,6 +14,6 @@
 
 ## Useful links
 
-- LooksRare developer documentation [:link:](https://docs.looksrare.org/developers/welcome)
-- LooksRare public API documentation [:link:](https://looksrare.github.io/api-docs)
-- LooksRare developer discord [:link:](https://discord.gg/jJA4qM5dXz)
+- [Developer documentation](https://docs.looksrare.org/developers/welcome)
+- [Public API documentation](https://looksrare.github.io/api-docs)
+- [Developer discord](https://discord.gg/jJA4qM5dXz)


### PR DESCRIPTION
Easier to find, I didn't even see the link emoji at first and thought the links were missing.