### PR TITLE
fix: Return all multicall function values

### DIFF
--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -40,11 +40,9 @@ export const multicall = async <T extends any[]>(
   // will include all values positionally and if the ABI
   // included names, values will additionally be available
   // by their name.
-  const results: T = returnData.map((data: BytesLike, i: number) => {
-    const [result] = itf.decodeFunctionResult(calls[i].functionName, data);
-
-    return result;
-  });
+  const results: T = returnData.map((data: BytesLike, i: number) =>
+    itf.decodeFunctionResult(calls[i].functionName, data)
+  );
 
   return results;
 };


### PR DESCRIPTION
The current implementation returns only the first value. For example:

[Fee Sharing's `userInfo`](https://etherscan.io/address/0xBcD7254A1D759EFA08eC7c3291B2E85c5dCC12ce#readContract) returns 3 values:

![image](https://user-images.githubusercontent.com/73018676/213009273-23541bac-ed14-4c80-be31-da45fb1b5c3d.png)

The current implementation of `multicall` will only return the first value, `shares`.
```
{
    "type": "BigNumber",
    "hex": "0x24999bf590b28b87be62"
  }
```
This PR returns the entire decoded function results. The same call as above returns:
```
[
    {
      "type": "BigNumber",
      "hex": "0x24999bf590b28b87be62"
    },
    {
      "type": "BigNumber",
      "hex": "0x035dd33e18fbf5"
    },
    {
      "type": "BigNumber",
      "hex": "0x58b160d0fcbea9f8"
    }
  ]
  ```
  
  